### PR TITLE
Use string.format() rather than f-strings to remain 3.5 compatible

### DIFF
--- a/factom_sdk/client/identities_client.py
+++ b/factom_sdk/client/identities_client.py
@@ -65,8 +65,8 @@ class IdentitiesClient:
         # = 37 + name_byte_count + 2(number_of_names) + 58(number_of_keys)
         total_bytes = 37 + name_byte_count + (len(names) * 2) + (len(signer_keys) * 58)
         if total_bytes > 10240:
-            raise Exception(f"calculated bytes of name and keys is {total_bytes}."
-                            f" It must be less than 10240, use less/shorter name or less keys.")
+            message = "Entry size {} must be less than 10240. Use less/shorter names or less keys.".format(total_bytes)
+            raise Exception(message)
 
         names_base64 = [CommonUtil.base64_encode(_name) for _name in names]
         data = {

--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages  # noqa: H301
 
 NAME = "factom-harmony-connect"
-VERSION = "1.0.1"
+VERSION = "1.0.2"
 REQUIRES = [
     "base58 >= 1.0.3",
     "ed25519 >= 1.4",

--- a/tests/test_identities_client.py
+++ b/tests/test_identities_client.py
@@ -123,8 +123,8 @@ class TestIdentityClient(TestCase):
                 "https://callback.com",
                 ["factom", "replicated"]
             )
-        self.assertTrue("calculated bytes of name and keys is 12771. It must be less than 10240, "
-                        "use less/shorter name or less keys." in str(cm.exception))
+        self.assertTrue("Entry size 12771 must be less than 10240. Use less/shorter names or less keys."
+                        in str(cm.exception))
 
         with patch("factom_sdk.request_handler.request_handler.requests.request") as mock_post:
             mock_post.return_value.ok = True


### PR DESCRIPTION
In response to the issue I raised here: https://github.com/FactomProject/factom-harmony-connect-python-sdk/issues/17

Just a simple fix and a version bump